### PR TITLE
Form dropdown fix

### DIFF
--- a/web/CASTNXT/app/controllers/events_controller.rb
+++ b/web/CASTNXT/app/controllers/events_controller.rb
@@ -22,7 +22,11 @@ class EventsController < ApplicationController
 
     forms = get_producer_forms(session[:userId])
     forms.each do |form|
-      formIds << form._id.to_str
+      fd = []
+      km = get_events(form._id)
+      fd << form._id.to_str
+      fd << km[0].title.to_str
+      formIds << fd
     end
 
     @properties = {name: session[:userName], formIds: formIds}
@@ -270,6 +274,10 @@ class EventsController < ApplicationController
   
   def get_producer_forms producerId
     return Form.where(:producer_id => producerId)
+  end
+
+  def get_events formId
+    return Event.where(:form_id => formId)
   end
   
   def get_form formId

--- a/web/CASTNXT/app/javascript/components/Admin/AdminCreateEvent.js
+++ b/web/CASTNXT/app/javascript/components/Admin/AdminCreateEvent.js
@@ -29,7 +29,7 @@ const commonStyle = {marginTop: "20px", marginBottom: "20px"}
 class AdminCreateEvent extends Component {
     constructor(props) {
         super(props)
-
+        console.log(properties)
         this.state = {
             tabValue: 0,
             selectedFormNo: "",
@@ -240,7 +240,6 @@ class AdminCreateEvent extends Component {
                                 <hr style={{ color: "black" }} />
                             </div>
                             
-                            
                             {this.state.tabValue === 0 &&
                                 <div>
                                     <div className="flex-row">
@@ -259,7 +258,7 @@ class AdminCreateEvent extends Component {
                                                 >
                                                     {this.state.formIds.map(formId => {
                                                         return (
-                                                            <MenuItem key={formId} value={formId}>Form {formId}</MenuItem>
+                                                            <MenuItem key={formId[0]} value={formId[0]}>Form {formId[1]}</MenuItem>
                                                         )
                                                     })}
                                                 </Select>


### PR DESCRIPTION
When producer creates form, instead of form_id GUID, they will see event name for parent form